### PR TITLE
Fix MailChimp Test Credentials

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,9 @@
 source "https://rubygems.org"
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec
 
-gem "workarea"
+gem 'workarea', github: 'workarea-commerce/workarea', branch: 'v3.4-stable'
 
 group :test, :development do
   gem "simplecov", require: false

--- a/app/controllers/workarea/storefront/users/accounts_controller.decorator
+++ b/app/controllers/workarea/storefront/users/accounts_controller.decorator
@@ -17,7 +17,7 @@ module Workarea
           {
             _id: group[:id],
             name: group[:name],
-            interests: group[:interests].to_unsafe_hash
+            interests: group[:interests]&.to_unsafe_hash || {}
           }
         end
       ]

--- a/test/support/workarea/mail_chimp_api_config.rb
+++ b/test/support/workarea/mail_chimp_api_config.rb
@@ -7,7 +7,7 @@ module Workarea
     end
 
     def set_key
-      Rails.application.secrets.mail_chimp = { api_key: 'a' }
+      Rails.application.secrets.mail_chimp = { api_key: 'c89583c2b238d7aaa6df3e4307bb68c1-us16' }
     end
 
     def reset_key

--- a/test/vcr_cassettes/get_default_list_interests.yml
+++ b/test/vcr_cassettes/get_default_list_interests.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -59,7 +59,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:

--- a/test/vcr_cassettes/get_member_details_no_match.yml
+++ b/test/vcr_cassettes/get_member_details_no_match.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:

--- a/test/vcr_cassettes/get_member_details_unsubscribed.yml
+++ b/test/vcr_cassettes/get_member_details_unsubscribed.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:

--- a/test/vcr_cassettes/interest_categories_read.yml
+++ b/test/vcr_cassettes/interest_categories_read.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -59,7 +59,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:

--- a/test/vcr_cassettes/mail_chimp/tasks/create_store-successful.yml
+++ b/test/vcr_cassettes/mail_chimp/tasks/create_store-successful.yml
@@ -11,7 +11,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.3
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -61,7 +61,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.3
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:

--- a/test/vcr_cassettes/mc_order_test.yml
+++ b/test/vcr_cassettes/mc_order_test.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -59,7 +59,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -109,7 +109,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -160,7 +160,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -208,7 +208,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -259,7 +259,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -302,7 +302,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -345,7 +345,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:

--- a/test/vcr_cassettes/mc_product_test.yml
+++ b/test/vcr_cassettes/mc_product_test.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -59,7 +59,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -107,7 +107,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -155,7 +155,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -198,7 +198,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:

--- a/test/vcr_cassettes/subscribe_to_default_list.yml
+++ b/test/vcr_cassettes/subscribe_to_default_list.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -59,7 +59,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -111,7 +111,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -160,7 +160,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -212,7 +212,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:

--- a/test/vcr_cassettes/subscribe_to_default_list_interest_groups.yml
+++ b/test/vcr_cassettes/subscribe_to_default_list_interest_groups.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -59,7 +59,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -111,7 +111,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -160,7 +160,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -212,7 +212,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:

--- a/test/vcr_cassettes/subscribe_to_default_list_with_groupings.yml
+++ b/test/vcr_cassettes/subscribe_to_default_list_with_groupings.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -59,7 +59,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -111,7 +111,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -160,7 +160,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -212,7 +212,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:

--- a/test/vcr_cassettes/subscribe_to_default_list_with_user_details.yml
+++ b/test/vcr_cassettes/subscribe_to_default_list_with_user_details.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -59,7 +59,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -111,7 +111,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -160,7 +160,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -212,7 +212,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:

--- a/test/vcr_cassettes/unsubscribe_from_default_list.yml
+++ b/test/vcr_cassettes/unsubscribe_from_default_list.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:

--- a/test/vcr_cassettes/update_member_on_default_list_change_email.yml
+++ b/test/vcr_cassettes/update_member_on_default_list_change_email.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -59,7 +59,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -111,7 +111,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -160,7 +160,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -212,7 +212,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:

--- a/test/vcr_cassettes/update_member_on_default_list_change_groupings.yml
+++ b/test/vcr_cassettes/update_member_on_default_list_change_groupings.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -59,7 +59,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -111,7 +111,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -160,7 +160,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -212,7 +212,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic YQo=
+      - Basic Yzg5NTgzYzJiMjM4ZDdhYWE2ZGYzZTQzMDdiYjY4YzEtdXMxNg==
       Content-Type:
       - application/json
       Accept-Encoding:


### PR DESCRIPTION
Update the MailChimp API Key to properly pass the client-side validation
that prevents `Gibbon` from making the calls needed in the tests for
MailChimp. Previously, this was a scrubbed credential and was one
character, which apparently doesn't fly for MailChimp and it caused the
client to block sending out requests, which was the reason behind the
tests failing. The API Key has been regenerated with a
`SecureRandom.hex` string and properly base64-encoded into the VCR
cassettes, which allow the tests to pass now.

MAILCHIMP-1