### PR TITLE
Fix Test Class Name

### DIFF
--- a/test/integration/workarea/mailchimp/tracking_params_test.rb
+++ b/test/integration/workarea/mailchimp/tracking_params_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 module Workarea
-  class MailChimp::SubscriptionTest < Workarea::IntegrationTest
+  class MailChimp::TrackingParamsTest < Workarea::IntegrationTest
     setup :set_inventory
     setup :set_product
 


### PR DESCRIPTION
This test class was mistakenly named `SubscriptionTest`, which caused
conflicts with the existing `SubscriptionTest` and erratic test failures
for users of the plugin. Update the class name to reflect the name of
the file it exists in, both to make it decoratable and to fix the
inconsistent setup code that was being loaded for its tests, causing the
intermittent test failures.

MAILCHIMP-2