### PR TITLE
Remove extraneous push in Release task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -41,10 +41,9 @@ task :release do
   Rake::Task["workarea:changelog"].execute
   system "git add CHANGELOG.md"
   system 'git commit -m "Update CHANGELOG"'
-  system "git push origin HEAD"
 
   system "git tag -a v#{Workarea::MailChimp::VERSION} -m 'Tagging #{Workarea::MailChimp::VERSION}'"
-  system "git push --tags"
+  system "git push origin HEAD --follow-tags"
 
   system "gem build workarea-mail_chimp.gemspec"
   system "gem push workarea-mail_chimp-#{Workarea::MailChimp::VERSION}.gem"


### PR DESCRIPTION
We're running out of minutes in our GitHub actions due to duplicate pushes
during a release. This consolidates the two pushes into one.

No changelog

WORKAREA-148