### PR TITLE
Add Rake Task to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ cd path/to/application
 bundle
 ```
 
+After deploying for the first time, run this on your production server
+to seed products/orders into MailChimp:
+
+```bash
+rails workarea:mail_chimp:install
+```
+
+Additional tasks can be discovered by running `rails --tasks`.
+
 Configuration
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
This task installs necessary data onto MailChimp in production, and we
don't document it anywhere. This causes some confusion for users as they
won't see MailChimp's abandoned cart functionality actually working
until there's some products loaded.